### PR TITLE
chore: sync fork with microsoft/perfview main (includes TrimLiveSessionState)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,7 +15,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Restore TraceEvent
         run: cd ./src/TraceEvent && dotnet restore --configfile ../../Nuget.config

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,7 +15,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Restore TraceEvent
         run: cd ./src/TraceEvent && dotnet restore --configfile ../../Nuget.config

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9 # https://github.com/actions/stale/blob/v9/README.md
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           ascending: true # Process the oldest issues first
           stale-issue-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           ascending: true # Process the oldest issues first
           stale-issue-label: 'stale'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <!-- These are the versions of the things we are CREATING in this repository -->
-    <ReleaseVersion>3.2.5</ReleaseVersion>
+    <ReleaseVersion>3.2.6</ReleaseVersion>
     <FastSerializationVersion>$(ReleaseVersion)</FastSerializationVersion>
     <HeapDumpDllVersion>$(ReleaseVersion)</HeapDumpDllVersion>
     <MemoryGraphVersion>$(ReleaseVersion)</MemoryGraphVersion>

--- a/src/PerfView.Tests/Dialogs/XamlMessageBoxTests.cs
+++ b/src/PerfView.Tests/Dialogs/XamlMessageBoxTests.cs
@@ -18,6 +18,7 @@ namespace PerfViewTests.Dialogs
         /// to the UI thread when called from a background thread, rather than throwing
         /// "The calling thread must be STA, because many UI components require this."
         /// Also verifies that calling from the UI thread directly still works (no-op dispatch).
+        /// An owner which has never been shown must also be ignored rather than assigned.
         /// This is the core regression test for issue #2300.
         /// </summary>
 #pragma warning disable VSTHRD200 // Keep the original regression test name stable.
@@ -35,7 +36,15 @@ namespace PerfViewTests.Dialogs
             // Part 1: Call directly from the UI thread (dispatch is a no-op).
             MessageBoxResult uiResult = XamlMessageBox.Show("Test message", "XamlMBTest_UI", MessageBoxButton.OK);
 
-            // Part 2: Call from a background thread — before the fix for issue #2300,
+            // Part 2: Use an owner that has not been shown.
+            Window unshownOwner = new Window();
+            MessageBoxResult unshownOwnerResult = XamlMessageBox.Show(
+                unshownOwner,
+                "Test message",
+                "XamlMBTest_UnshownOwner",
+                MessageBoxButton.OK);
+
+            // Part 3: Call from a background thread — before the fix for issue #2300,
             // this would throw InvalidOperationException ("The calling thread must be STA")
             // because XamlMessageBox creates a WPF Window requiring the UI thread.
             Task<MessageBoxResult> backgroundShowTask = Task.Run(() =>
@@ -48,9 +57,11 @@ namespace PerfViewTests.Dialogs
 
             MessageBoxResult bgResult = await backgroundShowTask;
 
-            // Both dialogs were auto-closed without clicking a button, so Result is None.
+            // All dialogs were auto-closed without clicking a button, so Result is None.
             Assert.Equal(MessageBoxResult.None, uiResult);
+            Assert.Equal(MessageBoxResult.None, unshownOwnerResult);
             Assert.Equal(MessageBoxResult.None, bgResult);
+            Assert.False(unshownOwner.IsLoaded);
         }
 
         private static bool s_autoCloseHandlerRegistered;

--- a/src/PerfView.Tests/EventViewer/EventWindowTests.cs
+++ b/src/PerfView.Tests/EventViewer/EventWindowTests.cs
@@ -1,0 +1,313 @@
+using EventSources;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Stacks;
+using PerfView;
+using PerfView.TestUtilities;
+using PerfViewTests.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PerfViewTests.EventViewer
+{
+    public class EventWindowTests : PerfViewTestBase
+    {
+        private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(2);
+
+        public EventWindowTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForOneSelectedCellAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.OneCell);
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForTwoSelectedCellsAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.TwoCells);
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForThreeSelectedCellsAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.ThreeCells);
+        }
+
+        [WpfFact]
+        [UseCulture("en-US")]
+        public Task TestOpenStacksForSelectedTimeRangeAsync()
+        {
+            return TestOpenStacksAsync(SelectedCellScenario.TimeRange);
+        }
+
+        private Task TestOpenStacksAsync(SelectedCellScenario scenario)
+        {
+            Func<Task<EventWindow>> setupAsync = async () =>
+            {
+                var tracePath = await WithTimeoutAsync(
+                    Task.Run(() => GetExtractedTracePath()),
+                    "extracting the ETL fixture").ConfigureAwait(false);
+
+                await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                var etlFile = Assert.IsType<ETLPerfViewData>(PerfViewFile.Get(tracePath));
+                try
+                {
+                    var perfViewFile = new SampledProfileFile(etlFile);
+                    var eventData = new PerfViewEventSource(perfViewFile);
+                    var opened = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    eventData.Open(GuiApp.MainWindow, GuiApp.MainWindow.StatusBar, () => opened.TrySetResult(true));
+                    await WithTimeoutAsync(opened.Task, "opening the Event Window").ConfigureAwait(true);
+
+                    var eventWindow = eventData.Viewer;
+                    eventWindow.EventTypes.SelectAll();
+                    eventWindow.Update();
+                    await WithTimeoutAsync(
+                        eventWindow.StatusBar.WaitForWorkCompleteAsync(),
+                        "loading events from the ETL fixture").ConfigureAwait(true);
+                    return eventWindow;
+                }
+                catch
+                {
+                    etlFile.Close();
+                    throw;
+                }
+            };
+
+            Func<EventWindow, Task> cleanupAsync = async eventWindow =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                try
+                {
+                    foreach (var stackWindow in StackWindow.StackWindows.ToArray())
+                    {
+                        stackWindow.Close();
+                    }
+
+                    eventWindow.Close();
+                }
+                finally
+                {
+                    eventWindow.DataSource.DataFile.Close();
+                }
+            };
+
+            Func<EventWindow, Task> testDriverAsync = async eventWindow =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                await VerifyScenarioAsync(eventWindow, scenario).ConfigureAwait(true);
+            };
+
+            return RunUITestAsync(setupAsync, testDriverAsync, cleanupAsync);
+        }
+
+        private async Task VerifyScenarioAsync(EventWindow eventWindow, SelectedCellScenario scenario)
+        {
+            Assert.Same(eventWindow.Dispatcher.Thread, Thread.CurrentThread);
+
+            var selectedCells = eventWindow.Grid.SelectedCells;
+            selectedCells.Clear();
+            var sampledProfileRows = GetSampledProfileRows(
+                eventWindow,
+                scenario == SelectedCellScenario.OneCell ? 1 : 2);
+            if (scenario == SelectedCellScenario.TimeRange)
+            {
+                var timeColumn = eventWindow.Grid.Columns.Single(column => Equals(column.Header, "Time MSec"));
+                selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], timeColumn));
+                selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], timeColumn));
+            }
+            else
+            {
+                selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[0]));
+                if (scenario == SelectedCellScenario.TwoCells)
+                {
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
+                }
+                else if (scenario == SelectedCellScenario.ThreeCells)
+                {
+                    // Select two cells from the first event to verify that rows are de-duplicated.
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[0], eventWindow.Grid.Columns[1]));
+                    selectedCells.Add(new DataGridCellInfo(sampledProfileRows[1], eventWindow.Grid.Columns[0]));
+                }
+            }
+
+            EventWindow.OpenCpuStacksCommand.Execute(null, eventWindow.Grid);
+            await WithTimeoutAsync(
+                eventWindow.StatusBar.WaitForWorkCompleteAsync(),
+                $"opening CPU stacks for {scenario}").ConfigureAwait(true);
+            await WithTimeoutAsync(
+                WaitForUIAsync(eventWindow.Dispatcher, CancellationToken.None),
+                $"dispatching the stack window for {scenario}").ConfigureAwait(true);
+
+            var stackWindow = Assert.Single(StackWindow.StackWindows);
+            try
+            {
+                await WithTimeoutAsync(
+                    stackWindow.StatusBar.WaitForWorkCompleteAsync(),
+                    $"computing the stack view for {scenario}").ConfigureAwait(true);
+                var selectedTimes = scenario == SelectedCellScenario.OneCell
+                    ? new[] { sampledProfileRows[0].TimeStampRelatveMSec }
+                    : new[] { sampledProfileRows[0].TimeStampRelatveMSec, sampledProfileRows[1].TimeStampRelatveMSec };
+                var expectedStart = selectedTimes.Min();
+                var expectedEnd = selectedTimes.Max();
+
+                Assert.Equal(expectedStart.ToString("n3"), stackWindow.StartTextBox.Text);
+                Assert.Equal(expectedEnd.ToString("n3"), stackWindow.EndTextBox.Text);
+                if (scenario == SelectedCellScenario.TimeRange)
+                {
+                    Assert.NotEmpty(GetSampleTimes(stackWindow.StackSource));
+                }
+                else
+                {
+                    Assert.Equal(
+                        selectedTimes.OrderBy(time => time),
+                        GetSampleTimes(stackWindow.StackSource).OrderBy(time => time));
+                }
+            }
+            finally
+            {
+                stackWindow.Close();
+            }
+        }
+
+        private static async Task<T> WithTimeoutAsync<T>(Task<T> task, string operation)
+        {
+            var timeoutTask = Task.Delay(TestTimeout);
+#pragma warning disable VSTHRD003 // Deliberately bound an externally-created operation in test code.
+            if (await Task.WhenAny(task, timeoutTask).ConfigureAwait(true) != task)
+            {
+                throw new TimeoutException($"Timed out after {TestTimeout} while {operation}.");
+            }
+
+            return await task.ConfigureAwait(true);
+#pragma warning restore VSTHRD003
+        }
+
+        private static async Task WithTimeoutAsync(Task task, string operation)
+        {
+            var timeoutTask = Task.Delay(TestTimeout);
+#pragma warning disable VSTHRD003 // Deliberately bound an externally-created operation in test code.
+            if (await Task.WhenAny(task, timeoutTask).ConfigureAwait(true) != task)
+            {
+                throw new TimeoutException($"Timed out after {TestTimeout} while {operation}.");
+            }
+
+            await task.ConfigureAwait(true);
+#pragma warning restore VSTHRD003
+        }
+
+        private enum SelectedCellScenario
+        {
+            OneCell,
+            TwoCells,
+            ThreeCells,
+            TimeRange,
+        }
+
+        private static double[] GetSampleTimes(StackSource stackSource)
+        {
+            var times = new List<double>();
+            stackSource.ForEach(sample => times.Add(sample.TimeRelativeMSec));
+            return times.ToArray();
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        private static string GetExtractedTracePath()
+        {
+            var inputDirectory = Path.Combine(AppContext.BaseDirectory, "EventViewer", "inputs");
+            var zipPath = Path.Combine(inputDirectory, "net.4.5.2.x86.etl.zip");
+            var extractedDirectory = Path.Combine(AppContext.BaseDirectory, "EventViewer", "unzipped");
+            var etlPath = Path.Combine(extractedDirectory, Path.GetFileNameWithoutExtension(zipPath));
+
+            Directory.CreateDirectory(extractedDirectory);
+            if (!File.Exists(etlPath) || File.GetLastWriteTimeUtc(etlPath) < File.GetLastWriteTimeUtc(zipPath))
+            {
+                var zipReader = new ZippedETLReader(zipPath)
+                {
+                    EtlFileName = etlPath,
+                    SymbolDirectory = Path.Combine(extractedDirectory, "Symbols"),
+                };
+                zipReader.UnpackArchive();
+            }
+
+            Assert.True(File.Exists(etlPath));
+            return etlPath;
+        }
+
+        private static ETWEventSource.ETWEventRecord[] GetSampledProfileRows(EventWindow eventWindow, int count)
+        {
+            var file = Assert.IsType<SampledProfileFile>(eventWindow.DataSource.DataFile);
+            var rows = eventWindow.Grid.Items
+                .OfType<ETWEventSource.ETWEventRecord>()
+                .Where(row => file.IsSampledProfileWithStack(row, eventWindow.StatusBar.LogWriter))
+                .Take(count)
+                .ToArray();
+
+            Assert.Equal(count, rows.Length);
+            return rows;
+        }
+
+        /// <summary>
+        /// Exposes the real ETL event and CPU-stack sources without running the Event Window's
+        /// unrelated cached-symbol lookup, which depends on a PerfView executable host.
+        /// </summary>
+        private sealed class SampledProfileFile : PerfViewFile
+        {
+            private readonly ETLPerfViewData m_file;
+            private readonly PerfViewStackSource m_cpuStacks;
+
+            public SampledProfileFile(ETLPerfViewData file)
+            {
+                m_file = file;
+                m_cpuStacks = new PerfViewStackSource(this, "CPU");
+                Title = file.Title;
+            }
+
+            public override string Title { get; }
+            public override string FormatName => m_file.FormatName;
+            public override string[] FileExtensions => m_file.FileExtensions;
+            public override string FilePath => m_file.FilePath;
+            public override PerfViewStackSource GetStackSource(string sourceName = null) => m_cpuStacks;
+
+            protected internal override EventSource OpenEventSourceImpl(TextWriter log) => m_file.OpenEventSourceImpl(log);
+
+            public bool IsSampledProfileWithStack(ETWEventSource.ETWEventRecord row, TextWriter log)
+            {
+                var traceEvent = m_file.GetTraceLog(log).GetEvent(row.Index);
+                return traceEvent is SampledProfileTraceData &&
+                    traceEvent.ProcessID != 0 &&
+                    traceEvent.CallStackIndex() != CallStackIndex.Invalid;
+            }
+
+            protected internal override StackSource OpenStackSourceImpl(
+                string streamName,
+                TextWriter log,
+                double startRelativeMSec = 0,
+                double endRelativeMSec = double.PositiveInfinity,
+                Predicate<TraceEvent> predicate = null)
+            {
+                return m_file.OpenStackSourceImpl(streamName, log, startRelativeMSec, endRelativeMSec, predicate);
+            }
+
+            public override void Close() => m_file.Close();
+        }
+    }
+}

--- a/src/PerfView.Tests/PerfView.Tests.csproj
+++ b/src/PerfView.Tests/PerfView.Tests.csproj
@@ -14,6 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\TraceEvent\TraceEvent.Tests\inputs\net.4.5.2.x86.etl.zip">
+      <Link>EventViewer\inputs\net.4.5.2.x86.etl.zip</Link>
+      <TargetPath>EventViewer\inputs\net.4.5.2.x86.etl.zip</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />

--- a/src/PerfView/Dialogs/XamlMessageBox.cs
+++ b/src/PerfView/Dialogs/XamlMessageBox.cs
@@ -57,7 +57,7 @@ public static class XamlMessageBox
         }
 
         MessageBoxWindow window = new(message, caption, buttons, icon, defaultResult);
-        if (owner is not null)
+        if (owner?.IsLoaded == true)
         {
             window.Owner = owner;
         }

--- a/src/PerfView/EventViewer/EventWindow.xaml.cs
+++ b/src/PerfView/EventViewer/EventWindow.xaml.cs
@@ -1,6 +1,9 @@
-﻿using EventSources;
+﻿using Diagnostics.Tracing.StackSources;
+using EventSources;
 using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Stacks;
 using Microsoft.Diagnostics.Tracing.TraceUtilities.FilterQueryExpression;
 using Microsoft.Diagnostics.Utilities;
 using Microsoft.IdentityModel.Tokens;
@@ -458,42 +461,39 @@ namespace PerfView
                 // If we have selected exactly two items, use that as the time limits, otherwise use what is the my dialog.
                 var startTimeRelativeMSec = m_source.StartTimeRelativeMSec;
                 var endTimeRelativeMSec = m_source.EndTimeRelativeMSec;
-                var selectedCells = Grid.SelectedCells;
-                if (selectedCells.Count == 1 || selectedCells.Count == 2)
+                var selectedCells = Grid.SelectedCells.ToList();
+                if (selectedCells.Count == 2)
                 {
                     string start = GetCellStringValue(selectedCells[0]);
                     double parsedStart;
                     if (!double.TryParse(start, out parsedStart))
                     {
-                        if (selectedCells.Count != 1)
-                        {
                             StatusBar.LogError("Could not parse " + start + " as a number.");
+                            OpenSelectedStacks(stackSourceName, selectedCells);
                             return;
-                        }
-                        StatusBar.Log("Assuming total current time range");
                     }
-                    else
-                    {
-                        startTimeRelativeMSec = parsedStart;
-                        endTimeRelativeMSec = parsedStart;
-                        if (selectedCells.Count == 2)
-                        {
-                            string end = GetCellStringValue(selectedCells[1]);
-                            if (!double.TryParse(end, out endTimeRelativeMSec))
-                            {
-                                StatusBar.LogError("Could not parse " + end + " as a number.");
-                                return;
-                            }
-                        }
 
-                        // Make sure that start < end
-                        if (endTimeRelativeMSec < startTimeRelativeMSec)
-                        {
-                            var tmp = startTimeRelativeMSec;
-                            startTimeRelativeMSec = endTimeRelativeMSec;
-                            endTimeRelativeMSec = tmp;
-                        }
+                    startTimeRelativeMSec = parsedStart;
+                    string end = this.GetCellStringValue(selectedCells[1]);
+                    if (!double.TryParse(end, out endTimeRelativeMSec))
+                    {
+                        this.StatusBar.LogError("Could not parse " + end + " as a number.");
+                        this.OpenSelectedStacks(stackSourceName, selectedCells);
+                        return;
                     }
+
+                    // Make sure that start < end
+                    if (endTimeRelativeMSec < startTimeRelativeMSec)
+                    {
+                        var tmp = startTimeRelativeMSec;
+                        startTimeRelativeMSec = endTimeRelativeMSec;
+                        endTimeRelativeMSec = tmp;
+                    }
+                }
+                else if (selectedCells.Count > 0)
+                {
+                    OpenSelectedStacks(stackSourceName, selectedCells);
+                    return;
                 }
 
                 // TODO FIX NOW: this should call a routine that does the opening of the stack view
@@ -557,6 +557,126 @@ namespace PerfView
                 });
             }
         }
+
+        private void OpenSelectedStacks(string stackSourceName, IList<DataGridCellInfo> selectedCells)
+        {
+            if (selectedCells == null || selectedCells.Count == 0)
+            {
+                StatusBar.LogError("No events selected.");
+                return;
+            }
+
+            StatusBar.StartWork("Reading " + DataSource.Name, delegate ()
+            {
+                PerfViewStackSource dataSource = null;
+                var dataFile = DataSource.DataFile;
+                if (dataFile != null)
+                {
+                    if (stackSourceName == null)
+                    {
+                        stackSourceName = dataFile.DefaultStackSourceName;
+                    }
+
+                    dataSource = dataFile.GetStackSource(stackSourceName);
+                }
+
+                if (dataSource == null)
+                {
+                    throw new ApplicationException("Could not find stack source " + stackSourceName);
+                }
+
+                // Collect unique event records (a row may have multiple selected cells).
+                var uniqueRecords = selectedCells
+                    .Select(c => c.Item as EventRecord)
+                    .Where(r => r != null)
+                    .Distinct()
+                    .ToList();
+
+                if (uniqueRecords.Count == 0)
+                {
+                    StatusBar.EndWork(delegate ()
+                    {
+                        StatusBar.LogError("No event records found in selection.");
+                    });
+                    return;
+                }
+
+                StackSource aggregateSource;
+
+                // For ETW sources, filter by exact EventIndex so concurrent events on other
+                // threads at the same timestamp are excluded.
+                var etwRecords = uniqueRecords.OfType<ETWEventSource.ETWEventRecord>().ToList();
+                double startTimeRelativeMSec;
+                double endTimeRelativeMSec;
+                if (etwRecords.Count == uniqueRecords.Count)
+                {
+                    startTimeRelativeMSec = etwRecords.Min(r => r.TimeStampRelatveMSec);
+                    endTimeRelativeMSec = etwRecords.Max(r => r.TimeStampRelatveMSec);
+
+                    var selectedIndices = new HashSet<EventIndex>(etwRecords.Select(r => r.Index));
+                    aggregateSource = dataSource.GetStackSource(
+                        StatusBar.LogWriter,
+                        startTimeRelativeMSec - .001,
+                        endTimeRelativeMSec + .001,
+                        data => selectedIndices.Contains(data.EventIndex));
+                }
+                else
+                {
+                    // Non-ETW records have no EventIndex for an exact event filter.
+                    // Use one stack source covering the selected records' time range.
+                    startTimeRelativeMSec = uniqueRecords.Min(r => r.TimeStampRelatveMSec);
+                    endTimeRelativeMSec = uniqueRecords.Max(r => r.TimeStampRelatveMSec);
+                    aggregateSource = dataSource.GetStackSource(
+                        StatusBar.LogWriter,
+                        startTimeRelativeMSec - .001,
+                        endTimeRelativeMSec + .001);
+                }
+
+                if (aggregateSource == null)
+                {
+                    StatusBar.EndWork(delegate ()
+                    {
+                        StatusBar.LogError("Could not open stacks for selected events.");
+                    });
+                    return;
+                }
+
+                if (!m_lookedUpCachedSymbolsForETLData)
+                {
+                    m_lookedUpCachedSymbolsForETLData = true;
+                    StatusBar.Log("Quick Looking up symbols from PDB cache.");
+                    var etlDataFile = dataFile as ETLPerfViewData;
+                    if (etlDataFile != null)
+                    {
+                        var traceLog = etlDataFile.GetTraceLog(StatusBar.LogWriter);
+                        using (var reader = etlDataFile.GetSymbolReader(StatusBar.LogWriter,
+                                   SymbolReaderOptions.CacheOnly | SymbolReaderOptions.NoNGenSymbolCreation))
+                        {
+                            var moduleFiles = ETLPerfViewData.GetInterestingModuleFiles(etlDataFile, 5.0, StatusBar.LogWriter, null);
+                            foreach (var moduleFile in moduleFiles)
+                            {
+                                traceLog.CodeAddresses.LookupSymbolsForModule(reader, moduleFile);
+                            }
+                        }
+                    }
+                    StatusBar.Log("Quick Done looking up symbols from PDB cache.");
+                }
+
+                StatusBar.EndWork(delegate ()
+                {
+                    App.CommandProcessor.NoExitOnElevate = true;
+
+                    var stackWindow = new PerfView.StackWindow(this, dataSource);
+                    stackWindow.StatusBar.Log("Read " + DataSource.Name);
+                    dataSource.ConfigureStackWindow(stackWindow);
+                    stackWindow.StartTextBox.Text = startTimeRelativeMSec.ToString();
+                    stackWindow.EndTextBox.Text = endTimeRelativeMSec.ToString();
+                    stackWindow.Show();
+                    stackWindow.SetStackSource(aggregateSource);
+                });
+            });
+        }
+
         private void DoProcessFilter(object sender, ExecutedRoutedEventArgs e)
         {
             var selectedCells = Grid.SelectedCells;

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -7685,7 +7685,7 @@ namespace PerfView
                 if (App.UserConfigData["WarnedAboutOsHeapAllocTypes"] == null)
                 {
                     XamlMessageBox.Show(
-                        stackWindow,
+                        stackWindow.ParentWindow,
                         """
                         Warning: Allocation type resolution only happens on window launch.
                         Thus if you manually lookup symbols in this view you will get method

--- a/src/PerfView/PerfViewData.cs
+++ b/src/PerfView/PerfViewData.cs
@@ -4571,7 +4571,19 @@ namespace PerfView
             return ret;
         }
 
-        // TODO not clear I want this method 
+        public virtual StackSource GetStackSource(TextWriter log, double startRelativeMSec, double endRelativeMSec, Predicate<TraceEvent> predicate)
+        {
+            StackSource ret = DataFile.OpenStackSourceImpl(SourceName, log, startRelativeMSec, endRelativeMSec, predicate);
+
+            if (ret == null)
+            {
+                throw new ApplicationException($"The {SourceName} does not support filtering by selected events.");
+            }
+
+            return ret;
+        }
+
+        // TODO not clear I want this method
         protected virtual StackSource OpenStackSource(
             string streamName, TextWriter log, double startRelativeMSec = 0, double endRelativeMSec = double.PositiveInfinity, Predicate<TraceEvent> predicate = null)
         {

--- a/src/PerfView/SupportFiles/UsersGuide.htm
+++ b/src/PerfView/SupportFiles/UsersGuide.htm
@@ -3641,10 +3641,27 @@
             (lower right corner).&nbsp;&nbsp;
         </li>
         <li>
-            <strong>Viewing Stacks</strong> If an event has a stack trace associated with it
-            the 'HasStack' field will be true. By selecting the time of that event and hitting
-            Alt-S you can see the stack for that time (which will include that events). You
-            can also select two times, and that region will be shown in the AnyStack view.
+            <strong>Viewing Stacks</strong> - An event has a stack when its 'HasStack' value is
+            true. To view it, click a cell in that event's row, then right click and choose
+            'Open Any Stacks', or press Alt-S. To view stacks for several events together, hold
+            Ctrl and click a cell in each row before opening the stacks.
+            <ul>
+                <li>
+                    Selecting more than one cell in the same row still includes that event only once.
+                </li>
+                <li>
+                    If you select exactly two cells containing numbers, PerfView tries to use the numbers
+                    as the start and end times and opens all stacks in that time range.
+                </li>
+                <li>
+                    If no cells are selected, PerfView opens the stacks for the time range currently
+                    shown in the Event Viewer.
+                </li>
+                <li>
+                    Some file types cannot identify stacks for individual events. For these files,
+                    PerfView opens all stacks between the first and last selected events.
+                </li>
+            </ul>
         </li>
         <li>
             <strong>Selecting columns </strong>- hitting the &#39;cols&#39; dropdown allows

--- a/src/TraceEvent/Parsers/ClrTraceEventParser.cs
+++ b/src/TraceEvent/Parsers/ClrTraceEventParser.cs
@@ -11956,6 +11956,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.Clr
         public bool IsDynamic { get { return (MethodFlags & MethodFlags.Dynamic) != 0; } }
         public bool IsGeneric { get { return (MethodFlags & MethodFlags.Generic) != 0; } }
         public bool IsJitted { get { return (MethodFlags & MethodFlags.Jitted) != 0; } }
+        public bool IsJitHelper { get { return (MethodFlags & MethodFlags.JitHelper) != 0; } }
 
         public OptimizationTier OptimizationTier
         {

--- a/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
+++ b/src/TraceEvent/TraceEvent.Tests/Parsing/EventPipeParsing.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -211,6 +212,177 @@ namespace TraceEventTests
                     }
 
                     // Stop after receiving the first event.
+                    session.Stop();
+                    await processingTask;
+                }
+            }
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+#else
+        [Fact(Skip = "EventPipeSession connection is only available to target apps on .NET Core 3.0 or later")]
+#endif
+        public async Task TrimLiveSessionStateDiscardsInternedStacksAndKeepsInterning()
+        {
+            // In a real time session the call stack interning tables grow for the lifetime of the
+            // session: every distinct stack observed is interned and nothing is released, so a long
+            // running session grows without bound.  TrimLiveSessionState discards them.
+            //
+            // This verifies both halves of the contract: the tables are actually emptied, and stacks
+            // observed afterwards are still interned and still resolve to methods.
+            const int MinimumInternedStacks = 8;
+
+            var client = new DiagnosticsClient(Process.GetCurrentProcess().Id);
+            var providers = new[]
+            {
+                new EventPipeProvider(SampleProfilerTraceEventParser.ProviderName, EventLevel.Informational),
+            };
+
+            using (var session = client.StartEventPipeSession(providers, requestRundown: false))
+            {
+                using (var traceSource = CreateFromEventPipeSession(session, EventPipeRundownConfiguration.Enable(client)))
+                {
+                    var traceLog = traceSource.TraceLog;
+                    var sampleEventParser = new SampleProfilerTraceEventParser(traceSource);
+
+                    int stacksBeforeReset = 0;
+                    int stacksAfterReset = -1;
+                    // RunContinuationsAsynchronously so awaiting this cannot resume inline on the
+                    // event processing thread - the continuation below stops the session and waits
+                    // on the processing task, which would deadlock if it ran on that thread.
+                    var stackAfterReset = new TaskCompletionSource<CallStackIndex>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                    sampleEventParser.ThreadSample += delegate (ClrThreadSampleTraceData e)
+                    {
+                        // TrimLiveSessionState has to run on the thread that processes events, which is the
+                        // thread this callback runs on.
+                        if (stacksAfterReset < 0)
+                        {
+                            // Let enough distinct stacks accumulate for the 'before' value to be meaningful.
+                            if (traceLog.CallStacks.Count < MinimumInternedStacks)
+                            {
+                                return;
+                            }
+
+                            stacksBeforeReset = traceLog.CallStacks.Count;
+                            traceLog.TrimLiveSessionState();
+                            stacksAfterReset = traceLog.CallStacks.Count;
+                            return;
+                        }
+
+                        // Anything interned after the reset must still be usable.
+                        CallStackIndex callStackIndex = e.CallStackIndex();
+                        if (callStackIndex != CallStackIndex.Invalid)
+                        {
+                            stackAfterReset.TrySetResult(callStackIndex);
+                        }
+                    };
+
+                    var processingTask = Task.Run(traceSource.Process);
+
+                    // Keep a little work running so the sampler sees a variety of stacks.
+                    var workDone = new CancellationTokenSource();
+                    var workTask = Task.Run(() =>
+                    {
+                        while (!workDone.IsCancellationRequested)
+                        {
+                            RecursiveWork(12);
+                        }
+                    });
+
+                    try
+                    {
+                        Task completed = await Task.WhenAny(stackAfterReset.Task, Task.Delay(TimeSpan.FromSeconds(60)));
+                        Assert.True(completed == stackAfterReset.Task,
+                            $"Timed out waiting for a call stack after the reset (interned before reset: {stacksBeforeReset}).");
+                    }
+                    finally
+                    {
+                        workDone.Cancel();
+                        await workTask;
+                    }
+
+                    Assert.True(stacksBeforeReset >= MinimumInternedStacks,
+                        $"Expected at least {MinimumInternedStacks} interned call stacks before the reset, saw {stacksBeforeReset}.");
+
+                    // The interning tables were emptied.
+                    Assert.Equal(0, stacksAfterReset);
+
+                    // ...and interning continued to work afterwards, all the way through to a method name.
+                    CallStackIndex postResetStack = await stackAfterReset.Task;
+                    CodeAddressIndex codeAddressIndex = traceLog.CallStacks.CodeAddressIndex(postResetStack);
+                    Assert.NotEqual(CodeAddressIndex.Invalid, codeAddressIndex);
+                    MethodIndex methodIndex = traceLog.CodeAddresses.MethodIndex(codeAddressIndex);
+                    Assert.NotEqual(MethodIndex.Invalid, methodIndex);
+                    Assert.NotEmpty(traceLog.CodeAddresses.Methods[methodIndex].FullMethodName);
+                    Assert.True(traceLog.CallStacks.Count > 0, "Expected the interning tables to refill after the reset.");
+
+                    // Every index in a post-reset stack must refer to the *new* table.  If any part of
+                    // the interning state survived the reset (for example the per-thread roots), stale
+                    // indexes from the old table leak back in here.  Those do not throw - GrowableArray
+                    // indexes its backing store without bounds checking against Count - so the stack
+                    // would silently resolve to the wrong frames.  Walking the whole chain and range
+                    // checking each link is what actually catches that.
+                    int stackCount = traceLog.CallStacks.Count;
+                    int depth = 0;
+                    for (CallStackIndex frame = postResetStack; frame != CallStackIndex.Invalid; frame = traceLog.CallStacks.Caller(frame))
+                    {
+                        Assert.InRange((int)frame, 0, stackCount - 1);
+                        Assert.True(++depth <= stackCount,
+                            "Walking the post-reset call stack did not terminate; the interning tables are inconsistent.");
+                    }
+
+                    session.Stop();
+                    await processingTask;
+                }
+            }
+        }
+
+        private static long RecursiveWork(int depth)
+        {
+            if (depth <= 0)
+            {
+                double sink = 0;
+                for (int i = 1; i < 10000; i++)
+                {
+                    sink += Math.Sqrt(i);
+                }
+                return (long)sink;
+            }
+
+            return RecursiveWork(depth - 1) + depth;
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+#else
+        [Fact(Skip = "EventPipeSession connection is only available to target apps on .NET Core 3.0 or later")]
+#endif
+        public async Task TrimLiveSessionStateThrowsWhenCalledOffTheDispatchThread()
+        {
+            var client = new DiagnosticsClient(Process.GetCurrentProcess().Id);
+            var providers = new[]
+            {
+                new EventPipeProvider(SampleProfilerTraceEventParser.ProviderName, EventLevel.Informational),
+            };
+
+            using (var session = client.StartEventPipeSession(providers, requestRundown: false))
+            {
+                using (var traceSource = CreateFromEventPipeSession(session, EventPipeRundownConfiguration.None()))
+                {
+                    var traceLog = traceSource.TraceLog;
+
+                    // Wait until dispatching is under way, so we are asserting against a live dispatcher
+                    // rather than a session that has not started. The assertion below holds either way -
+                    // this thread is never the dispatch thread - so a timeout here is not a failure.
+                    var dispatching = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    traceSource.AllEvents += delegate (TraceEvent _) { dispatching.TrySetResult(true); };
+                    var processingTask = Task.Run(traceSource.Process);
+                    await Task.WhenAny(dispatching.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+
+                    Assert.Throws<InvalidOperationException>(() => traceLog.TrimLiveSessionState());
+
                     session.Stop();
                     await processingTask;
                 }

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -384,7 +384,15 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
             // We need to look up the event to get the dispatch Target assigned.
             TraceEvent rtEvent = realTimeSource.Lookup(data.eventRecord);
-            realTimeSource.Dispatch(rtEvent);
+            m_DispatchThreadID = Thread.CurrentThread.ManagedThreadId;
+            try
+            {
+                realTimeSource.Dispatch(rtEvent);
+            }
+            finally
+            {
+                m_DispatchThreadID = -1;
+            }
 
             // Clean up interim data structures - they're not necessary after the event has been processed (Dispatched).
             eventsToStacks.Clear();
@@ -871,6 +879,27 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
 
         /// <summary>
+        /// The managed thread ID of the thread currently dispatching an event to the real time source,
+        /// or -1 when no dispatch is in progress.
+        /// </summary>
+        private int m_DispatchThreadID = -1;
+
+        /// <summary>
+        /// Throws unless the caller is running on the thread that is currently dispatching an event.
+        /// Operations that mutate state the dispatcher is actively using can only run from within an
+        /// event callback, and this is how they enforce it.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The caller is not on the dispatch thread.</exception>
+        internal void ThrowIfNotRunningOnDispatchThread()
+        {
+            if (m_DispatchThreadID != Thread.CurrentThread.ManagedThreadId)
+            {
+                throw new InvalidOperationException(
+                    "This operation must be called from within an event callback, on the thread dispatching the event.");
+            }
+        }
+
+        /// <summary>
         /// Removes all but the last 'keepCount' entries in 'growableArray' by sliding them down.
         /// </summary>
         private static void RemoveAllButLastEntries<T>(ref GrowableArray<T> growableArray, int keepCount)
@@ -886,6 +915,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         {
             realTimeEvent = toSend;
             TraceEvent eventInRealTimeSource = null;
+            m_DispatchThreadID = Thread.CurrentThread.ManagedThreadId;
             try
             {
                 eventInRealTimeSource = realTimeSource.Lookup(toSend.eventRecord);
@@ -897,6 +927,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             finally
             {
                 realTimeEvent = null;
+                m_DispatchThreadID = -1;
             }
 
             // Optimization, remove 'toSend' from the finalization queue.
@@ -973,6 +1004,46 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             {
                 RemoveAllButLastEntries(ref cswitchBlockingEventsToStacks, realTimeQueue.Count);
             }
+        }
+
+        /// <summary>
+        /// Releases the state a live session can afford to discard.  Today that is the call stack
+        /// interning tables (see <see cref="CallStacks"/>); more may be trimmed here in future.
+        /// <para>
+        /// In a real time session those tables grow for the lifetime of the session: every distinct
+        /// call stack that is observed is interned and nothing is ever released.  For a long running
+        /// process with diverse stacks that growth is unbounded.  Trace files do not have this problem
+        /// because the session is finite, which is why this is restricted to real time sessions.
+        /// </para>
+        /// <para>
+        /// Every <see cref="CallStackIndex"/> obtained before this call is invalidated and must not be
+        /// used afterwards, so only call this when no such index is still live.  Call stacks observed
+        /// after the call are interned from scratch, so no information is lost going forward - only
+        /// the ability to resolve indexes handed out earlier.
+        /// </para>
+        /// <para>
+        /// Must be called from within an event callback, on the thread dispatching that event.  Calling
+        /// it concurrently with event processing would race with call stack interning
+        /// </para>
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The TraceLog is not a real time session, or the caller is not on the dispatch thread.
+        /// </exception>
+        public void TrimLiveSessionState()
+        {
+            if (!IsRealTime)
+            {
+                throw new InvalidOperationException("TrimLiveSessionState is only supported for real time sessions.");
+            }
+
+            ThrowIfNotRunningOnDispatchThread();
+
+            callStacks.Clear();
+
+            // These map events to the indexes we just invalidated, so also need clearing.
+            // A length reset is enough here - they hold structs, so nothing is retained.
+            eventsToStacks.Clear();
+            cswitchBlockingEventsToStacks.Clear();
         }
 
         /// <summary>
@@ -7857,6 +7928,19 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         internal void SetSize(int origSize)
         {
             callStacks.RemoveRange(origSize, callStacks.Count - origSize);
+        }
+
+        /// <summary>
+        /// Discards every interned call stack, returning the interning tables to their initial state.
+        /// Only meaningful for a real time session, where these tables would otherwise grow for the
+        /// lifetime of the session.  See <see cref="TraceLog.TrimLiveSessionState"/>.
+        /// </summary>
+        internal void Clear()
+        {
+            // GrowableArray.Clear() only resets the length so we have to assign fresh arrays
+            callStacks = new GrowableArray<CallStackInfo>();
+            callees = new GrowableArray<List<CallStackIndex>>();
+            threads = new GrowableArray<List<CallStackIndex>>();
         }
 
         /// <summary>

--- a/src/TraceEvent/TraceLog.cs
+++ b/src/TraceEvent/TraceLog.cs
@@ -346,8 +346,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 TraceProcess process = processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
                 process.InsertJITTEDMethod(data.MethodStartAddress, data.MethodSize, delegate ()
                 {
-                    TraceManagedModule module = process.LoadedModules.GetOrCreateManagedModule(data.ModuleID, data.TimeStampQPC);
-                    MethodIndex methodIndex = CodeAddresses.Methods.NewMethod(GetFullName(data), module.ModuleFile.ModuleFileIndex, data.MethodToken);
+                    TraceModuleFile moduleFile = process.LoadedModules.GetOrCreateMethodModuleFile(data);
+                    MethodIndex methodIndex = CodeAddresses.Methods.NewMethod(GetFullName(data), moduleFile.ModuleFileIndex, data.MethodToken);
                     return new TraceProcess.MethodLookupInfo(data.MethodStartAddress, data.MethodSize, methodIndex);
                 });
             };
@@ -1363,7 +1363,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             eventCount = 0;
 
             // FIX NOW HACK, because Method and Module unload methods are missing.
-            jittedMethods = new List<MethodLoadUnloadVerboseTraceData>();
+            methodLoadEvents = new List<MethodLoadUnloadVerboseTraceData>();
             jsJittedMethods = new List<MethodLoadUnloadJSTraceData>();
             sourceFilesByID = new Dictionary<JavaScriptSourceKey, string>();
 
@@ -1684,17 +1684,17 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                         bookKeepingEvent = true;
                     }
 
-                    if (data.IsJitted)
+                    if (ShouldTrackMethodLoad(data.MethodFlags))
                     {
                         TraceProcess process = processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
                         process.InsertJITTEDMethod(data.MethodStartAddress, data.MethodSize, delegate ()
                         {
-                            TraceManagedModule module = process.LoadedModules.GetOrCreateManagedModule(data.ModuleID, data.TimeStampQPC);
-                            MethodIndex methodIndex = CodeAddresses.Methods.NewMethod(TraceLog.GetFullName(data), module.ModuleFile.ModuleFileIndex, data.MethodToken);
+                            TraceModuleFile moduleFile = process.LoadedModules.GetOrCreateMethodModuleFile(data);
+                            MethodIndex methodIndex = CodeAddresses.Methods.NewMethod(TraceLog.GetFullName(data), moduleFile.ModuleFileIndex, data.MethodToken);
                             return new TraceProcess.MethodLookupInfo(data.MethodStartAddress, data.MethodSize, methodIndex);
                         });
 
-                        jittedMethods.Add((MethodLoadUnloadVerboseTraceData)data.Clone());
+                        methodLoadEvents.Add((MethodLoadUnloadVerboseTraceData)data.Clone());
                     }
                 };
             rawEvents.Clr.MethodLoadVerbose += onMethodStart;
@@ -2427,9 +2427,9 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             userStackKeyToInfo = null;
 
             // TODO FIX NOW hack because unloadMethod not present
-            foreach (var jittedMethod in jittedMethods)
+            foreach (var methodLoadEvent in methodLoadEvents)
             {
-                codeAddresses.AddMethod(jittedMethod);
+                codeAddresses.AddMethod(methodLoadEvent);
             }
 
             foreach (var jsJittedMethod in jsJittedMethods)
@@ -3531,20 +3531,34 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         }
         internal static string GetFullName(MethodLoadUnloadVerboseTraceData data)
         {
-            string sig = data.MethodSignature;
-            int parens = sig.IndexOf('(');
+            return GetFullName(data.MethodFlags, data.MethodNamespace, data.MethodName, data.MethodSignature);
+        }
+
+        private static string GetFullName(MethodFlags methodFlags, string methodNamespace, string methodName, string methodSignature)
+        {
+            if ((methodFlags & MethodFlags.JitHelper) != 0)
+            {
+                return methodName;
+            }
+
+            int parens = methodSignature.IndexOf('(');
             string args;
             if (parens >= 0)
             {
-                args = sig.Substring(parens);
+                args = methodSignature.Substring(parens);
             }
             else
             {
                 args = "";
             }
 
-            string fullName = data.MethodNamespace + "." + data.MethodName + args;
+            string fullName = methodNamespace + "." + methodName + args;
             return fullName;
+        }
+
+        private static bool ShouldTrackMethodLoad(MethodFlags methodFlags)
+        {
+            return (methodFlags & (MethodFlags.Jitted | MethodFlags.JitHelper)) != 0;
         }
 
         internal int FindPageIndex(long timeQPC)
@@ -4202,8 +4216,8 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
         private bool noStack;                               // This event should never have a stack associated with it, so skip them if we every try to attach a stack.
         private TraceThread thread;                         // cache of the TraceThread for the current event.
 
-        // TODO FIX NOW remove the jittedMethods ones.
-        private List<MethodLoadUnloadVerboseTraceData> jittedMethods;
+        // TODO FIX NOW remove the methodLoadEvents ones.
+        private List<MethodLoadUnloadVerboseTraceData> methodLoadEvents;
         private List<MethodLoadUnloadJSTraceData> jsJittedMethods;
         private Dictionary<JavaScriptSourceKey, string> sourceFilesByID;
 
@@ -7225,6 +7239,29 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             }
             return module;
         }
+
+        internal TraceModuleFile GetOrCreateMethodModuleFile(MethodLoadUnloadVerboseTraceData data)
+        {
+            if (data.IsJitHelper)
+            {
+                return GetOrCreateJitHelperModuleFile();
+            }
+
+            return GetOrCreateManagedModule(data.ModuleID, data.TimeStampQPC).ModuleFile;
+        }
+
+        private TraceModuleFile GetOrCreateJitHelperModuleFile()
+        {
+            if (jitHelperModuleFile == null)
+            {
+                // Stash process-private, dynamically generated runtime helpers under an invalid file path
+                // so they are clearly synthetic while still displaying cleanly in stacks.
+                string modulePath = "[generatedruntimehelpers:processindex=" + process.ProcessIndex + "]\\generatedruntimehelpers.dll";
+                jitHelperModuleFile = process.Log.ModuleFiles.GetOrCreateModuleFile(modulePath, 0);
+            }
+
+            return jitHelperModuleFile;
+        }
         /// <summary>
         /// Finds the index and module for an a given managed module ID.  If not found, new module
         /// should be inserted at index + 1;
@@ -7411,6 +7448,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
 
         private TraceProcess process;
         private GrowableArray<TraceLoadedModule> modules;               // Contains unmanaged modules sorted by key
+        private TraceModuleFile jitHelperModuleFile;
         #endregion
     }
 
@@ -8536,7 +8574,7 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
             MethodIndex methodIndex = Microsoft.Diagnostics.Tracing.Etlx.MethodIndex.Invalid;
             ILMapIndex ilMap = ILMapIndex.Invalid;
             ModuleFileIndex moduleFileIndex = Microsoft.Diagnostics.Tracing.Etlx.ModuleFileIndex.Invalid;
-            TraceManagedModule module = null;
+            TraceModuleFile moduleFile = null;
             TraceProcess process = log.Processes.GetOrCreateProcess(data.ProcessID, data.TimeStampQPC);
             ForAllUnresolvedCodeAddressesInRange(process, data.MethodStartAddress, data.MethodSize, true, delegate (ref CodeAddressInfo info)
             {
@@ -8545,10 +8583,10 @@ namespace Microsoft.Diagnostics.Tracing.Etlx
                 if (info.GetMethodIndex(this) == Microsoft.Diagnostics.Tracing.Etlx.MethodIndex.Invalid)
                 {
                     // Lazily create the method since many methods never have code samples in them.
-                    if (module == null)
+                    if (moduleFile == null)
                     {
-                        module = process.LoadedModules.GetOrCreateManagedModule(data.ModuleID, data.TimeStampQPC);
-                        moduleFileIndex = module.ModuleFile.ModuleFileIndex;
+                        moduleFile = process.LoadedModules.GetOrCreateMethodModuleFile(data);
+                        moduleFileIndex = moduleFile.ModuleFileIndex;
                         methodIndex = methods.NewMethod(TraceLog.GetFullName(data), moduleFileIndex, data.MethodToken);
                         if (data.IsJitted)
                         {


### PR DESCRIPTION
Syncs this fork's `main` with `microsoft/perfview` `main` (8 commits), bringing in
microsoft/perfview#2452 — `TraceLog.TrimLiveSessionState()`, the fix for the profiling memory
leak in getsentry/sentry-dotnet#5469.

As before this fork carries no commits of its own, so this is a content-level fast-forward. A
true fast-forward push isn't possible (the org ruleset requires a pull request and has no bypass
actors), so this PR is the mechanism. Please merge with **"Create a merge commit"** — squash would
collapse the upstream commits and rebase would rewrite their SHAs.

Once this lands, sentry-dotnet's submodule can be bumped to pin the fix.
